### PR TITLE
Support type hints, default values, *args, **kwargs

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -62,6 +62,40 @@ function searchForDunderInit(editor, activeLine) {
 
 }
 
+function paramStringBuilder(paramName, indentAmount) {
+	/*
+	Parse the argument (in that case python argument) and build self parameter initialization string
+	So far it checks for type hints, default values.
+	Naming convention and linting is left for python server (e.g. Pylance) responsible as we do not want to 
+	fix and take care of all the possible problems of the world :)
+	*/
+	const settings = vscode.workspace.getConfiguration('fillinit');
+	let result = ""
+	let typeHint = ""
+
+	paramName = paramName.trim().replace(/^\**/, "")
+
+	// checking if there is a default param value as we don't need it
+	if (paramName.includes("=")) {
+		paramName = (paramName.split("=")[0])
+	}
+
+	// check if there is a type hinting included
+	if (paramName.includes(":")) {
+		[paramName, typeHint] = paramName.split(":")
+		paramName = paramName.trim()
+		typeHint = typeHint.trim()
+		if (settings.includeTypeHints) {
+			return `${' '.repeat(indentAmount)}self.${paramName}: ${typeHint} = ${paramName}\n`
+		}
+	}
+	return `${' '.repeat(indentAmount)}self.${paramName} = ${paramName}\n`
+	
+
+
+
+}
+
 function getArgs(lineText) {
 	/*
 	Creates and indents the arguments inside of the dunder init method
@@ -86,31 +120,30 @@ function getArgs(lineText) {
 	lineText.forEach(argument => {
 		let validArg = true;
 
-		// checks for *args or **kwargs parameters
-		if (argument.includes('*')) {
-			validArg = false;
-		}
-		// checks for optional parameters
-		if (argument.includes('=')) {
-			argument = argument.split('=')[0]
-		}
-		// checks for type hints in parameters
-		if (argument.includes(':')) {
-			argument = argument.split(':')[0]
-		}
-		// I should have commented this... wtf does this regex do?!
-		// if (!/^[a-zA-Z0-9_.-]*$/.test(argument)) {
+		
+		// // checks for *args or **kwargs parameters
+		// if (argument.includes('*')) {
 		// 	validArg = false;
 		// }
-		// checks for digits in front of variables
-		if (/^\d/.test(argument)) {
-			validArg = false;
-		}
+		// // checks for optional parameters
+		// if (argument.includes('=')) {
+		// 	argument = argument.split('=')[0]
+		// }
+		// // checks for type hints in parameters
+		// if (argument.includes(':')) {
+		// 	argument = argument.split(':')[0]
+		// }
+		// // I should have commented this... wtf does this regex do?!
+		// // if (!/^[a-zA-Z0-9_.-]*$/.test(argument)) {
+		// // 	validArg = false;
+		// // }
+		// // checks for digits in front of variables
+		// if (/^\d/.test(argument)) {
+		// 	validArg = false;
+		// }
 
 		// adds a new line to the arguments in the for of ```self.var = var```
-		if (validArg) {
-			text += (' '.repeat(indentAmount)) + 'self.' + argument + ' = ' + argument + '\n';
-		}
+		text += paramStringBuilder(argument, indentAmount)
 	});
 
 	return text;

--- a/extension.js
+++ b/extension.js
@@ -70,9 +70,9 @@ function paramStringBuilder(paramName, indentAmount) {
 	fix and take care of all the possible problems of the world :)
 	*/
 	const settings = vscode.workspace.getConfiguration('fillinit');
-	let result = ""
 	let typeHint = ""
 
+	// trimming * and ** in args, kwargs as they are not needed
 	paramName = paramName.trim().replace(/^\**/, "")
 
 	// checking if there is a default param value as we don't need it
@@ -118,31 +118,6 @@ function getArgs(lineText) {
 
 	let text = '';
 	lineText.forEach(argument => {
-		let validArg = true;
-
-		
-		// // checks for *args or **kwargs parameters
-		// if (argument.includes('*')) {
-		// 	validArg = false;
-		// }
-		// // checks for optional parameters
-		// if (argument.includes('=')) {
-		// 	argument = argument.split('=')[0]
-		// }
-		// // checks for type hints in parameters
-		// if (argument.includes(':')) {
-		// 	argument = argument.split(':')[0]
-		// }
-		// // I should have commented this... wtf does this regex do?!
-		// // if (!/^[a-zA-Z0-9_.-]*$/.test(argument)) {
-		// // 	validArg = false;
-		// // }
-		// // checks for digits in front of variables
-		// if (/^\d/.test(argument)) {
-		// 	validArg = false;
-		// }
-
-		// adds a new line to the arguments in the for of ```self.var = var```
 		text += paramStringBuilder(argument, indentAmount)
 	});
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,11 @@
 					"type": "number",
 					"default": 10,
 					"description": "The maximum amount of lines to search for a __init__ method (centered around the cursor)"
+				},
+				"fillinit.includeTypeHints": {
+					"type": "boolean",
+					"default": true,
+					"description": "Wheter to include type hints in self.* variables declaration in __init__ method"
 				}
 			}
 		}


### PR DESCRIPTION
Hi

Because I'm using this extension extensively (thank's for it) I'd like to contribute and add the things which I'm missing and thing of them as very useful/productive.

* added type hints support options. If set to true also type hints will be added to parameter initialization on dunder init
* extract logic for building "init string parameters" to separate function

Feel free to modify, add, or remove this code - although I think it might help e.g. in type hinting :)